### PR TITLE
AFT-29095: Ally specific changes

### DIFF
--- a/spec/logger_spec.rb
+++ b/spec/logger_spec.rb
@@ -89,6 +89,17 @@ EOF
                                         foo: 'foo_value'
                                       } ]])
       end
+
+      it 'dynamic_logs' do
+        logger.dynamic_tags({key: ->(){"value"}})
+        logger.info("log message")
+        logger.flush
+        expect(@my_logger.log).to eq([['foo', {
+          messages: 'log message',
+          severity: 'INFO',
+          key: 'value'
+        } ]])
+      end
     end
 
     it 'is thread safe' do

--- a/spec/logger_spec.rb
+++ b/spec/logger_spec.rb
@@ -69,7 +69,7 @@ EOF
         logger.tagged(tags) { logger.info('hello') }
         expect(@my_logger.log).to eq([['foo', {
                                          abc: 'xyz',
-                                         messages: ['hello'],
+                                         messages: 'hello',
                                          severity: 'INFO',
                                          uuid: 'uuid_value',
                                          foo: 'foo_value'
@@ -77,11 +77,17 @@ EOF
         @my_logger.clear
         logger.tagged(tags) { logger.info('world'); logger.info('bye') }
         expect(@my_logger.log).to eq([['foo', {
-                                         messages: ['world', 'bye'],
+                                         messages: 'world',
                                          severity: 'INFO',
                                          uuid: 'uuid_value',
                                          foo: 'foo_value'
-                                       } ]])
+                                       } ],
+                                      ['foo', {
+                                        messages: 'bye',
+                                        severity: 'INFO',
+                                        uuid: 'uuid_value',
+                                        foo: 'foo_value'
+                                      } ]])
       end
     end
 
@@ -112,9 +118,11 @@ EOF
         sleep(0.1)
       end
       expect(@my_logger.log).to match_array([
-        ['foo', { messages: ['hello', 'hello'], severity: 'INFO', uuid: 'hello', foo: 'foo_value' } ],
-        ['foo', { messages: ['world', 'world'], severity: 'INFO', uuid: nil, foo: nil } ]
-      ])
+                                              ["foo", {severity: "INFO", messages: "world"}],
+                                              ["foo", {uuid: nil, foo: nil, severity: "INFO", messages: "world"}],
+                                              ["foo", {severity: "INFO", messages: "hello"}],
+                                              ["foo", {uuid: "hello", foo: "foo_value", severity: "INFO", messages: "hello"}]
+                                            ])
     end
 
 
@@ -133,7 +141,8 @@ EOF
           logger.info(ascii)
           logger.info('咲く')
         }
-        expect(@my_logger.log[0][1][:messages]).to eq("花\n咲く")
+        expect(@my_logger.log[0][1][:messages]).to eq("花")
+        expect(@my_logger.log[1][1][:messages]).to eq("咲く")
         expect(ascii.encoding).to eq(Encoding::ASCII_8BIT)
       end
     end
@@ -146,7 +155,7 @@ EOF
           logger.tagged([request]) {
             logger.error(e)
           }
-          expect(@my_logger.log[0][1][:messages][0]).
+          expect(@my_logger.log[0][1][:messages]).
             to match(%r|divided by 0 \(ZeroDivisionError\).*spec/logger_spec\.rb:|m)
         end
       end
@@ -158,7 +167,7 @@ EOF
         logger.tagged([request]) {
           logger.info(x)
         }
-        expect(@my_logger.log[0][1][:messages][0]).to eq(x.inspect)
+        expect(@my_logger.log[0][1][:messages]).to eq(x.inspect)
       end
     end
 
@@ -249,7 +258,7 @@ EOF
         logger = ActFluentLoggerRails::Logger.new(config_file: File.new(@config_file.path),
                                                   flush_immediately: true)
         logger.info('Immediately!')
-        expect(@my_logger.log[0][1][:messages][0]).to eq('Immediately!')
+        expect(@my_logger.log[0][1][:messages]).to eq('Immediately!')
       end
     end
 


### PR DESCRIPTION
List of changes made as part of this PR

1. Enabled non-blocking write to the fluent server to avoid blocking of application threads
2. Introduced two non-standard logger methods. 
1. [auto_flushing] By default logger buffers the logs, but this is problematic for rake tasks. So added the option to set a flush flag at runtime. This will be used only for rake tasks. 
2. [dynamic_tags] Since this logger uses a buffer, every flush results in tags being cleared. Hence subsequent logs will not contain tags. This dynamic tags feature will compute tags every time a new log is added. This will be used only from Rake tasks. 
3. Support for the Hash message. If the log message is a hash, hash key values will be pushed as fluent log fields, thus they end up as fields in Geneva. 
4. Gem was sending all buffered logs as a single event. Because of this, some information was lost(or incorrect) - severity, tags, etc. This will not be very useful for monitoring, the fix is to send every log as an individual fluent log event to Geneva. 